### PR TITLE
fix(#35): use an empty light engine export before a lighting engine is initialized

### DIFF
--- a/patches/Unified/Terraria/Lighting.cs.patch
+++ b/patches/Unified/Terraria/Lighting.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Lighting.cs
 +++ src/Unified/Terraria/Lighting.cs
-@@ -3,11 +_,38 @@
+@@ -3,11 +_,41 @@
  using Terraria.Graphics;
  using Terraria.Graphics.Light;
  using Terraria.ID;
@@ -10,6 +10,9 @@
  namespace Terraria;
  
 -public class Lighting
++// LightMap is never null so long as the area isn't empty.  Unsafe functions do
++// not care about this restriction as API consumers are expected to guard
++// against out-of-bounds accesses in their own code regardless.
 +public sealed class LightingEngineExport(LightMap workingMap, Rectangle area)
 +{
 +	public Rectangle Area => area;
@@ -40,11 +43,17 @@
  {
  	private const float DEFAULT_GLOBAL_BRIGHTNESS = 1.2f;
  	private const float BLIND_GLOBAL_BRIGHTNESS = 1f;
-@@ -18,6 +_,8 @@
+@@ -18,6 +_,14 @@
  	private static readonly LegacyLighting LegacyEngine = new LegacyLighting(Main.Camera);
  	private static ILightingEngine _activeEngine;
  
-+	public static LightingEngineExport EngineExport { get; private set; }
++	// This empty export has a null map to reduce memory consumption and extra
++	// time spent initializing an export that goes generally unused.  We just
++	// need to populate with a sane default value to avoid exceptions before a
++	// game world is entered.
++	private static readonly LightingEngineExport empty_export = new(workingMap: null, area: Rectangle.Empty);
++
++	public static LightingEngineExport EngineExport { get; private set; } = empty_export;
 +
  	public static float GlobalBrightness { get; set; }
  
@@ -57,7 +66,7 @@
  		TimeLogger.Lighting.AddTime(fromTimestamp);
  	}
  
-@@ -98,20 +_,23 @@
+@@ -98,7 +_,7 @@
  
  	public static float Brightness(int x, int y)
  	{
@@ -66,12 +75,7 @@
  		return GlobalBrightness * (color.X + color.Y + color.Z) / 3f;
  	}
  
- 	public static Vector3 GetSubLight(Vector2 position)
- 	{
-+		if (Main.gameMenu)
-+			return Vector3.One;
-+
- 		Vector2 vector = position / 16f - new Vector2(0.5f, 0.5f);
+@@ -108,10 +_,10 @@
  		Vector2 vector2 = new Vector2(vector.X % 1f, vector.Y % 1f);
  		int num = (int)vector.X;
  		int num2 = (int)vector.Y;


### PR DESCRIPTION
Fixes #35.

Lazy bug fix for a crash that seems to be specific to Unified, there's probably a better solution. Just wanted to stop crashing when scrolling my character select