### PR TITLE
fix: resize `MapRenderer` data on main thread

### DIFF
--- a/patches/Unified/Terraria/MapRenderer.Unified.cs
+++ b/patches/Unified/Terraria/MapRenderer.Unified.cs
@@ -1,12 +1,23 @@
 ﻿using System.Collections.Generic;
 using Terraria.DataStructures;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
 
 namespace Terraria;
 
 public partial class MapRenderer
 {
 	public static void Resize()
+	{
+		if (ThreadCheck.IsMainThread) {
+			Resize_Inner();
+		}
+		else {
+			Main.RunOnMainThread(Resize_Inner);
+		}
+	}
+
+	private static void Resize_Inner()
 	{
 		for (int x = 0; x < numTargetsX; x++) {
 			for (int y = 0; y < numTargetsY; y++) {


### PR DESCRIPTION
Avoids possible race conditions when connecting to servers or joining worlds due to a new list being committed before it's fully populated. Also avoids disposing of RTs on a separate thread.