### PR TITLE
fix(#49): replace both directory seprators with a dot, fixes asset loading on *nix

### DIFF
--- a/patches/Unified/Terraria/Unified/ContentSources.cs
+++ b/patches/Unified/Terraria/Unified/ContentSources.cs
@@ -29,7 +29,7 @@ internal static class ContentSources
 
 		public override Stream OpenStream(string assetName)
 		{
-			return assembly.GetManifestResourceStream(rootPath + '.' + assetName.Replace('\\', '.') + GetExtension(assetName))
+			return assembly.GetManifestResourceStream(rootPath + '.' + assetName.Replace('\\', '.').Replace('/', ',') + GetExtension(assetName))
 				?? throw AssetLoadException.FromMissingAsset(assetName);
 		}
 


### PR DESCRIPTION
Fixes #49.